### PR TITLE
ESC button toggles shows/hides the calculator

### DIFF
--- a/js/its-calc.js
+++ b/js/its-calc.js
@@ -205,6 +205,19 @@
       container.querySelector('button[data-active="true"]').removeAttribute('data-active');
     }
   };
+    
+  // Toggle hide/show -AAF
+  document.addEventListener('keydown', function(e) {
+      var element = e.target;
+      // Make sure the container is defined -AAF
+      if (container) {
+         // Capure the key ESC
+          if (e.keyCode && e.keyCode === 27) {
+              // Apparently not supported in IE6, but well \_(ツ)_/
+              container.hidden = !container.hidden;
+          }
+      }
+  });
 
   
 
@@ -217,7 +230,8 @@
     var cur_bal = parseFloat(total_display.value);
     
     // If Selected text or if its one of the calculator buttons.
-    if (t && e.target.getAttribute('its-calc') !== 'total') {
+    // Also, make sure the container is displayed (I used === false just to be sure) -AAF
+    if (t && e.target.getAttribute('its-calc') !== 'total' && container.hidden === false) {
       hidden_display.value = t;
       t = hidden_display.value.replace(/,/g, '');
       if (parseFloat(t)) {


### PR DESCRIPTION
Added a feature where the ESC button shows/hides the calculator's container. Very useful for small devices and nerds like me.

Additional note: When the calculator is hidden, calculations are not made (just in case the user wants to go back where they were).

Finally, I think it really needed a little "dispose" option. If accepted, I'll move this feature to a new function.